### PR TITLE
feat: stop spinner on process exit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,9 +61,12 @@ export class Spinner {
     this.refresh();
   }
 
-  private onProcessExit = () => {
+  private onProcessExit = (signalName: string) => {
     if (this.running) {
       this.stop();
+      // SIGTERM is 15, SIGINT is 2
+      const signalCode = signalName === 'SIGTERM' ? 15 : 2;
+      process.exit(128 + signalCode);
     }
   };
 
@@ -126,11 +129,11 @@ export class Spinner {
 
   stop() {
     this.end(false);
-    this.clearListeners();
   }
 
   private end(keepComponent = true) {
     clearInterval(this.interval);
+    this.clearListeners();
     if (keepComponent) this.component.finish();
     else renderer.removeComponent(this.component);
     this.running = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,23 +61,32 @@ export class Spinner {
     this.refresh();
   }
 
-  private onProcessExit = (signalName: string) => {
+  private onProcessExit = (signal?: string | number) => {
     if (this.running) {
       this.stop();
       // SIGTERM is 15, SIGINT is 2
-      const signalCode = signalName === 'SIGTERM' ? 15 : 2;
-      process.exit(128 + signalCode);
+      let signalCode;
+      if (signal === 'SIGTERM') {
+        signalCode = 15 + 128;
+      } else if (signal === 'SIGINT') {
+        signalCode = 2 + 128;
+      } else {
+        signalCode = Number(signal);
+      }
+      process.exit(signalCode);
     }
   };
 
   private addListeners() {
     process.once('SIGTERM', this.onProcessExit);
     process.once('SIGINT', this.onProcessExit);
+    process.once('exit', this.onProcessExit);
   }
 
   private clearListeners() {
     process.off('SIGTERM', this.onProcessExit);
     process.off('SIGINT', this.onProcessExit);
+    process.off('exit', this.onProcessExit);
   }
 
   refresh() {

--- a/src/test/spinner-test.ts
+++ b/src/test/spinner-test.ts
@@ -87,6 +87,29 @@ test('end methods', async (t) => {
       process.exit = originalExit;
     }
   });
+
+  await t.test('process exit (via exit event)', async () => {
+    let exitCode: unknown = 0;
+    const exitStub = ((code: unknown) => {
+      exitCode = code;
+    }) as typeof process.exit;
+    const originalExit = process.exit;
+    process.exit = exitStub;
+
+    try {
+      await interceptStdout(async () => {
+        const spinner = new Spinner();
+        spinner.start();
+        // TODO (43081j): maybe this'll spook other things? if something is
+        // listening for SIGTERM
+        process.emit('exit', 1);
+      });
+
+      assert.equal(exitCode, 1);
+    } finally {
+      process.exit = originalExit;
+    }
+  });
 });
 
 async function testSpinner(frames?: string[], text?: string, symbolFormatter?: (v: string) => string) {

--- a/src/test/spinner-test.ts
+++ b/src/test/spinner-test.ts
@@ -3,6 +3,7 @@ import {test} from 'node:test';
 import {Spinner, Symbols} from '..';
 import {createFinishingRenderedLine, createRenderedLine, interceptStdout} from './utils.js';
 import * as constants from '../constants';
+import process from 'node:process';
 
 async function testEndMethod(method: keyof Symbols, type: 'str' | 'obj', customSymbol?: string) {
   const stdout = await interceptStdout(async () => {
@@ -59,6 +60,18 @@ test('end methods', async (t) => {
     });
 
     assert.equal(stdout, createFinishingRenderedLine('', ''));
+  });
+
+  await t.test('process exit', async () => {
+    const stdout = await interceptStdout(async () => {
+      const spinner = new Spinner();
+      spinner.start();
+      // TODO (43081j): maybe this'll spook other things? if something is
+      // listening for SIGTERM
+      process.emit('SIGTERM');
+    });
+
+    assert.equal(stdout, constants.CLEAR_LINE + constants.SHOW_CURSOR);
   });
 });
 


### PR DESCRIPTION
Stops the spinner when `SIGTERM` or `SIGINT` is received.

cc @PondWader 