### PR TITLE
feat: add option `disableNewLineEnding`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type SpinnerOptions = {
   colors?: boolean | ColorOptions;
   frames?: string[];
   symbols?: Partial<Symbols>;
+  disableNewLineEnding?: boolean;
 };
 
 type Style = Parameters<typeof util.styleText>[0];
@@ -51,7 +52,7 @@ export class Spinner {
   private component = new TextComponent('');
   private colors?: ColorOptions;
 
-  constructor(display: DisplayOptions | string = '', {colors, frames = constants.DEFAULT_FRAMES, symbols = {} as Partial<Symbols>}: SpinnerOptions = {}) {
+  constructor(display: DisplayOptions | string = '', {disableNewLineEnding, colors, frames = constants.DEFAULT_FRAMES, symbols = {} as Partial<Symbols>}: SpinnerOptions = {}) {
     // Merge symbols with defaults
     this.symbols = {...constants.DEFAULT_SYMBOLS, ...symbols};
 
@@ -63,6 +64,8 @@ export class Spinner {
         ...colors
       };
     }
+
+    if (disableNewLineEnding === true) this.component.disableNewLineEnding();
 
     if (typeof display === 'string') display = {text: display};
     delete display.symbol;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -5,6 +5,7 @@ export class TextComponent {
   onChange?: () => void;
   onFinish?: () => void;
   finished = false;
+  newLineEnding = true;
 
   constructor(public text: string) {}
 
@@ -23,6 +24,10 @@ export class TextComponent {
 
   output() {
     return this.text;
+  }
+
+  disableNewLineEnding() {
+    this.newLineEnding = false;
   }
 }
 
@@ -72,7 +77,7 @@ export class Renderer {
     let output = '';
     let finished = true;
     for (const component of this.components) {
-      output += component.output() + '\n';
+      output += component.output() + (component.newLineEnding ? '\n' : '');
       if (!component.finished) finished = false;
     }
 
@@ -86,13 +91,10 @@ export class Renderer {
   }
 
   clear() {
-    process.stdout.cursorTo(0);
     for (let i = 0; i < this.lastLinesAmt - 1; i++) {
-      process.stdout.moveCursor(0, -1);
-      if (i > 0) {
-        process.stdout.clearLine(1);
-      }
+      process.stdout.write(constants.CLEAR_LINE + constants.UP_LINE);
     }
+    process.stdout.write(constants.CLEAR_LINE);
   }
 
   _reset() {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -86,10 +86,13 @@ export class Renderer {
   }
 
   clear() {
+    process.stdout.cursorTo(0);
     for (let i = 0; i < this.lastLinesAmt - 1; i++) {
-      process.stdout.write(constants.CLEAR_LINE + constants.UP_LINE);
+      process.stdout.moveCursor(0, -1);
+      if (i > 0) {
+        process.stdout.clearLine(1);
+      }
     }
-    process.stdout.write(constants.CLEAR_LINE);
   }
 
   _reset() {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -76,8 +76,9 @@ export class Renderer {
 
     let output = '';
     let finished = true;
-    for (const component of this.components) {
-      output += component.output() + (component.newLineEnding ? '\n' : '');
+    for (let i = 0; i < this.components.length; i++) {
+      const component = this.components[i];
+      output += component.output() + (i !== this.components.length - 1 || component.newLineEnding ? '\n' : '');
       if (!component.finished) finished = false;
     }
 

--- a/src/test/renderer-test.ts
+++ b/src/test/renderer-test.ts
@@ -110,4 +110,18 @@ test('Renderer', async (t) => {
     });
     assert.ok(stdout.endsWith(constants.SHOW_CURSOR), 'shows cursor');
   });
+
+  await t.test('newLineEnding behaves as expected', async () => {
+    const stdout = await interceptStdout(async () => {
+      const renderer = new Renderer();
+      const component1 = new TextComponent('hello');
+      component1.disableNewLineEnding();
+      const component2 = new TextComponent('hi');
+      component2.disableNewLineEnding();
+      renderer.addComponent(component1);
+      renderer.addComponent(component2);
+    });
+
+    assert.ok(stdout.endsWith('hello\nhi'), 'new lines are placed correctly');
+  });
 });

--- a/src/test/spinner-test.ts
+++ b/src/test/spinner-test.ts
@@ -140,10 +140,10 @@ test('end methods', async (t) => {
   });
 });
 
-async function testSpinner(frames?: string[], text?: string, symbolFormatter?: (v: string) => string, colors?: ColorOptions | boolean) {
+async function testSpinner(frames?: string[], text?: string, symbolFormatter?: (v: string) => string, colors?: ColorOptions | boolean, disableNewLineEnding?: boolean) {
   renderer._reset();
 
-  const spinner = new TickMeasuredSpinner({text, symbolFormatter}, {frames, colors});
+  const spinner = new TickMeasuredSpinner({text, symbolFormatter}, {frames, colors, disableNewLineEnding});
 
   const stdout = await interceptStdout(
     () =>
@@ -165,11 +165,10 @@ async function testSpinner(frames?: string[], text?: string, symbolFormatter?: (
     new Array(spinner.tickCount)
       .fill(undefined)
       .map((_, i) => {
-        return createRenderedLine(frames[i % frames.length], text ?? '', i === 0, colors, 'spinner', symbolFormatter);
+        return createRenderedLine(frames[i % frames.length], text ?? '', i === 0, colors, 'spinner', symbolFormatter, disableNewLineEnding);
       })
       .join('') +
-      constants.CLEAR_LINE +
-      constants.UP_LINE +
+      (!disableNewLineEnding ? constants.CLEAR_LINE + constants.UP_LINE : '') +
       constants.CLEAR_LINE +
       constants.SHOW_CURSOR
   );
@@ -253,4 +252,5 @@ test('spinner', async (t) => {
     })
   );
   await t.test('displays colors with symbol formatter', () => testSpinner(undefined, 'lorem ipsum dolor', (s) => `a${s}a`, true));
+  await t.test('disableNewLineEnding prevents ending new line', () => testSpinner(undefined, undefined, undefined, undefined, true));
 });

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -4,7 +4,7 @@ import {isAbsolute} from 'path';
 import {ColorOptions, DisplayOptions, Spinner, SpinnerOptions} from '../index.js';
 import * as util from 'node:util';
 
-export function createRenderedOutput(components: {symbol: string; symbolType?: keyof ColorOptions; text: string}[], firstLine = false, prevLines = -1, colors?: ColorOptions | boolean, symbolFormatter?: (v: string) => string) {
+export function createRenderedOutput(components: {symbol: string; symbolType?: keyof ColorOptions; text: string}[], firstLine = false, prevLines = -1, colors?: ColorOptions | boolean, symbolFormatter?: (v: string) => string, disableNewLineEnding?: boolean) {
   if (colors === true) colors = constants.DEFAULT_COLORS;
   else if (colors) colors = {...constants.DEFAULT_COLORS, ...colors};
 
@@ -14,16 +14,16 @@ export function createRenderedOutput(components: {symbol: string; symbolType?: k
     return text;
   };
 
-  let out = (!firstLine ? (constants.CLEAR_LINE + constants.UP_LINE).repeat(prevLines === -1 ? components.length : prevLines) : '') + constants.CLEAR_LINE + constants.HIDE_CURSOR;
+  let out = (!firstLine && !disableNewLineEnding ? (constants.CLEAR_LINE + constants.UP_LINE).repeat(prevLines === -1 ? components.length : prevLines) : '') + constants.CLEAR_LINE + constants.HIDE_CURSOR;
   for (const component of components) {
     const symbol = component.symbol ? (component.symbolType ? format(component.symbol, component.symbolType) : component.symbol) + ' ' : '';
-    out += symbol + format(component.text, 'text') + '\n';
+    out += symbol + format(component.text, 'text') + (!disableNewLineEnding ? '\n' : '');
   }
   return out;
 }
 
-export function createRenderedLine(symbol: string, text: string, firstLine: boolean = false, colors?: ColorOptions | boolean, symbolType?: keyof ColorOptions, symbolFormatter?: (v: string) => string) {
-  return createRenderedOutput([{symbol, text, symbolType}], firstLine, -1, colors, symbolFormatter);
+export function createRenderedLine(symbol: string, text: string, firstLine: boolean = false, colors?: ColorOptions | boolean, symbolType?: keyof ColorOptions, symbolFormatter?: (v: string) => string, disableNewLineEnding?: boolean) {
+  return createRenderedOutput([{symbol, text, symbolType}], firstLine, -1, colors, symbolFormatter, disableNewLineEnding);
 }
 
 export function createFinishingRenderedLine(symbol: string, text: string, colors?: ColorOptions | boolean, symbolType?: keyof ColorOptions, symbolFormatter?: (v: string) => string) {


### PR DESCRIPTION
Clears the output using the stream methods and changes the logic slightly to clear per line, other than line `0`.

@PondWader I'm trying to fix this:

```ts
  const finalSpinner = new Spinner('Attempting risky operation...');
  finalSpinner.start();
  try {
    await new Promise((resolve) => setTimeout(resolve, 2000));
    throw new Error('Intentional error');
  } catch (error) {
    console.error('\nError caught:', error.message);
  } finally {
    finalSpinner.stop();
  }
```

basically, this currently ends up clearing the `console.error` when we `stop` the spinner

I'm not 100% sure why, but this change seems to fix that...

I'm leaving this as a draft until we can understand what's going on here. if you could take a look, that'd be super helpful