### PR TITLE
feat: add `colors` option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm i picospinner
 ```js
 import {Spinner} from 'picospinner';
 
-const spinner = new Spinner('Loading...');
+const spinner = new Spinner('Loading...', {colors: true});
 spinner.start();
 setTimeout(() => {
   spinner.succeed('Finished.');
@@ -32,7 +32,8 @@ import {Spinner} from 'picospinner';
 const spinner = new Spinner('Loading...', {
   symbols: {
     warn: '⚠'
-  }
+  },
+  colors: true
 });
 spinner.start();
 setTimeout(() => {
@@ -60,7 +61,28 @@ Calling `spinner.stop();` will stop the spinner and remove it.
 
 ### Colours
 
-Colours can be achieved by using a formatter such as picocolors or chalk. First install picocolors:
+As of version **2.1.0** colours can be easily applied with the `colors` option which uses the [`styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options) function from [`node:util`](https://nodejs.org/api/util.html) if it is available (Node versions greater than **22.0.0**, **21.7.0** or **20.12.0**). If it's not available, no colours will be displayed.
+
+The option accepts a boolean value controlling whether or not to display the default colours or it can be passed an object defining styles for each component type as shown below:
+
+```js
+// Create spinner with default colours
+const spinner = new Spinner('Loading...', {
+  colors: true
+});
+
+// Create spinner with custom colours
+const spinner = new Spinner('Loading...', {
+  colors: {
+    text: 'gray',
+    succeed: ['bold', 'green'],
+    spinner: 'magenta'
+    // The other properties will use the default colours
+  }
+});
+```
+
+Alternatively, colours can be displayed by using a third-party formatter such as picocolors or chalk. First install picocolors:
 
 ```
 npm i picocolors

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ const spinner = new Spinner('Loading...', {
     text: 'gray',
     succeed: ['bold', 'green'],
     spinner: 'magenta'
-    // The other properties will use the default colours
+    // The other properties (fail, warn, info) will use the default colours since they're not specified in this example
   }
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "picospinner",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "picospinner",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.6.0",
         "@types/bun": "^1.1.6",
         "@types/capture-console": "^1.0.5",
-        "@types/node": "^20.14.9",
+        "@types/node": "^22.13.8",
         "c8": "^10.1.2",
         "capture-console": "^1.0.2",
         "fast-string-truncated-width": "^1.1.0",
@@ -22,6 +22,9 @@
         "tsup": "^8.3.5",
         "typescript": "^5.5.2",
         "typescript-eslint": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1035,14 +1038,21 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "22.13.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
+      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@eslint/js": "^9.6.0",
     "@types/bun": "^1.1.6",
     "@types/capture-console": "^1.0.5",
-    "@types/node": "^20.14.9",
+    "@types/node": "^22.13.8",
     "c8": "^10.1.2",
     "capture-console": "^1.0.2",
     "fast-string-truncated-width": "^1.1.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import {Symbols} from './index.js';
+import {ColorOptions, Symbols} from './index.js';
 
 export const DEFAULT_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 export const DEFAULT_TICK_MS = 50;
@@ -11,4 +11,11 @@ export const DEFAULT_SYMBOLS: Symbols = {
   fail: '✖',
   warn: '!',
   info: 'ℹ'
+};
+export const DEFAULT_COLORS: ColorOptions = {
+  succeed: 'green',
+  fail: 'red',
+  warn: 'yellow',
+  info: 'blue',
+  spinner: 'cyan'
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,14 +35,6 @@ export type Symbols = {
   info: string;
 };
 
-const defaultColours: ColorOptions = {
-  succeed: 'green',
-  fail: 'red',
-  warn: 'yellow',
-  info: 'blue',
-  spinner: 'cyan'
-};
-
 // Global renderer so that multiple spinners can run at the same time
 export const renderer = new Renderer();
 
@@ -64,10 +56,10 @@ export class Spinner {
     this.symbols = {...constants.DEFAULT_SYMBOLS, ...symbols};
 
     // Setup colors if the option is passed
-    if (colors === true) this.colors = defaultColours;
+    if (colors === true) this.colors = constants.DEFAULT_COLORS;
     else if (typeof colors === 'object') {
       this.colors = {
-        ...defaultColours,
+        ...constants.DEFAULT_COLORS,
         ...colors
       };
     }
@@ -139,7 +131,7 @@ export class Spinner {
         this.currentSymbol = this.format(displayOpts.symbol, displayOpts.symbolType);
       } else this.currentSymbol = displayOpts.symbol;
     }
-    if (typeof displayOpts.text === 'string') this.setText(this.format(displayOpts.text, 'text'), false);
+    if (typeof displayOpts.text === 'string') this.setText(displayOpts.text, false);
     if (displayOpts.symbolFormatter) this.symbolFormatter = displayOpts.symbolFormatter;
 
     if (render) this.refresh();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as constants from './constants.js';
 import {Renderer, TextComponent} from './renderer.js';
+import * as util from 'node:util';
 
 export type Formatter = (input: string) => string;
 
@@ -7,6 +8,24 @@ export type DisplayOptions = {
   symbolFormatter?: Formatter;
   text?: string;
   symbol?: string;
+  symbolType?: 'succeed' | 'fail' | 'warn' | 'info' | 'spinner';
+};
+
+export type SpinnerOptions = {
+  colors?: boolean | ColorOptions;
+  frames?: string[];
+  symbols?: Partial<Symbols>;
+};
+
+type Style = Parameters<typeof util.styleText>[0];
+
+export type ColorOptions = {
+  succeed?: Style;
+  fail?: Style;
+  warn?: Style;
+  info?: Style;
+  spinner?: Style;
+  text?: Style;
 };
 
 export type Symbols = {
@@ -14,6 +33,14 @@ export type Symbols = {
   fail: string;
   warn: string;
   info: string;
+};
+
+const defaultColours: ColorOptions = {
+  succeed: 'green',
+  fail: 'red',
+  warn: 'yellow',
+  info: 'blue',
+  spinner: 'cyan'
 };
 
 // Global renderer so that multiple spinners can run at the same time
@@ -30,10 +57,20 @@ export class Spinner {
   private symbols: Symbols;
   private frames: string[];
   private component = new TextComponent('');
+  private colors?: ColorOptions;
 
-  constructor(display: DisplayOptions | string = '', {frames = constants.DEFAULT_FRAMES, symbols = {} as Partial<Symbols>} = {}) {
+  constructor(display: DisplayOptions | string = '', {colors, frames = constants.DEFAULT_FRAMES, symbols = {} as Partial<Symbols>}: SpinnerOptions = {}) {
     // Merge symbols with defaults
     this.symbols = {...constants.DEFAULT_SYMBOLS, ...symbols};
+
+    // Setup colors if the option is passed
+    if (colors === true) this.colors = defaultColours;
+    else if (typeof colors === 'object') {
+      this.colors = {
+        ...defaultColours,
+        ...colors
+      };
+    }
 
     if (typeof display === 'string') display = {text: display};
     delete display.symbol;
@@ -57,7 +94,7 @@ export class Spinner {
   }
 
   tick() {
-    this.currentSymbol = this.frames[this.frameIndex++];
+    this.currentSymbol = this.format(this.frames[this.frameIndex++], 'spinner');
     if (this.frameIndex === this.frames.length) this.frameIndex = 0;
     this.refresh();
   }
@@ -98,9 +135,11 @@ export class Spinner {
 
   setDisplay(displayOpts: DisplayOptions = {}, render = true) {
     if (typeof displayOpts.symbol === 'string') {
-      this.currentSymbol = displayOpts.symbol;
+      if (typeof displayOpts.symbolType === 'string') {
+        this.currentSymbol = this.format(displayOpts.symbol, displayOpts.symbolType);
+      } else this.currentSymbol = displayOpts.symbol;
     }
-    if (typeof displayOpts.text === 'string') this.setText(displayOpts.text, false);
+    if (typeof displayOpts.text === 'string') this.setText(this.format(displayOpts.text, 'text'), false);
     if (displayOpts.symbolFormatter) this.symbolFormatter = displayOpts.symbolFormatter;
 
     if (render) this.refresh();
@@ -108,30 +147,30 @@ export class Spinner {
   }
 
   setText(text: string, render = true) {
-    this.text = text;
+    this.text = this.format(text, 'text');
     if (this.running) {
       if (render) this.refresh();
     }
   }
 
   succeed(display?: DisplayOptions | string) {
-    if (typeof display === 'string') this.setDisplay({text: display, symbol: this.symbols.succeed});
-    else this.setDisplay({...display, symbol: this.symbols.succeed});
+    if (typeof display === 'string') this.setDisplay({text: display, symbol: this.symbols.succeed, symbolType: 'succeed'});
+    else this.setDisplay({...display, symbol: this.symbols.succeed, symbolType: 'succeed'});
   }
 
   fail(display?: DisplayOptions | string) {
-    if (typeof display === 'string') this.setDisplay({text: display, symbol: this.symbols.fail});
-    else this.setDisplay({...display, symbol: this.symbols.fail});
+    if (typeof display === 'string') this.setDisplay({text: display, symbol: this.symbols.fail, symbolType: 'fail'});
+    else this.setDisplay({...display, symbol: this.symbols.fail, symbolType: 'fail'});
   }
 
   warn(display?: DisplayOptions | string) {
-    if (typeof display === 'string') this.setDisplay({text: display, symbol: this.symbols.warn});
-    else this.setDisplay({...display, symbol: this.symbols.warn});
+    if (typeof display === 'string') this.setDisplay({text: display, symbol: this.symbols.warn, symbolType: 'warn'});
+    else this.setDisplay({...display, symbol: this.symbols.warn, symbolType: 'warn'});
   }
 
   info(display?: DisplayOptions | string) {
-    if (typeof display === 'string') this.setDisplay({text: display, symbol: this.symbols.info});
-    else this.setDisplay({...display, symbol: this.symbols.info});
+    if (typeof display === 'string') this.setDisplay({text: display, symbol: this.symbols.info, symbolType: 'info'});
+    else this.setDisplay({...display, symbol: this.symbols.info, symbolType: 'info'});
   }
 
   stop() {
@@ -144,5 +183,16 @@ export class Spinner {
     if (keepComponent) this.component.finish();
     else renderer.removeComponent(this.component);
     this.running = false;
+  }
+
+  private format(component: string, componentName: keyof ColorOptions): string {
+    if (this.colors === undefined) return component;
+
+    const color = this.colors[componentName];
+    // Ensure that the Node version contains util.styleText
+    if (color && util.styleText !== undefined) {
+      return util.styleText(color, component);
+    }
+    return component;
   }
 }

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -2,14 +2,14 @@ import capcon from 'capture-console';
 import * as constants from '../constants.js';
 import {isAbsolute} from 'path';
 import {ColorOptions, DisplayOptions, Spinner, SpinnerOptions} from '../index.js';
-import {styleText} from 'util';
+import * as util from 'node:util';
 
 export function createRenderedOutput(components: {symbol: string; symbolType?: keyof ColorOptions; text: string}[], firstLine = false, prevLines = -1, colors?: ColorOptions | boolean, symbolFormatter?: (v: string) => string) {
   if (colors === true) colors = constants.DEFAULT_COLORS;
   else if (colors) colors = {...constants.DEFAULT_COLORS, ...colors};
 
   const format = (text: string, componentType: keyof ColorOptions) => {
-    if (colors && colors[componentType]) text = styleText(colors[componentType], text);
+    if (colors && colors[componentType] && util.styleText) text = util.styleText(colors[componentType], text);
     if (symbolFormatter && componentType !== 'text') return symbolFormatter(text);
     return text;
   };

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,22 +1,33 @@
 import capcon from 'capture-console';
 import * as constants from '../constants.js';
 import {isAbsolute} from 'path';
-import {DisplayOptions, Spinner, Symbols} from '../index.js';
+import {ColorOptions, DisplayOptions, Spinner, SpinnerOptions} from '../index.js';
+import {styleText} from 'util';
 
-export function createRenderedOutput(components: {symbol: string; text: string}[], firstLine = false, prevLines = -1) {
+export function createRenderedOutput(components: {symbol: string; symbolType?: keyof ColorOptions; text: string}[], firstLine = false, prevLines = -1, colors?: ColorOptions | boolean, symbolFormatter?: (v: string) => string) {
+  if (colors === true) colors = constants.DEFAULT_COLORS;
+  else if (colors) colors = {...constants.DEFAULT_COLORS, ...colors};
+
+  const format = (text: string, componentType: keyof ColorOptions) => {
+    if (colors && colors[componentType]) text = styleText(colors[componentType], text);
+    if (symbolFormatter && componentType !== 'text') return symbolFormatter(text);
+    return text;
+  };
+
   let out = (!firstLine ? (constants.CLEAR_LINE + constants.UP_LINE).repeat(prevLines === -1 ? components.length : prevLines) : '') + constants.CLEAR_LINE + constants.HIDE_CURSOR;
   for (const component of components) {
-    out += (component.symbol ? component.symbol + ' ' : '') + component.text + '\n';
+    const symbol = component.symbol ? (component.symbolType ? format(component.symbol, component.symbolType) : component.symbol) + ' ' : '';
+    out += symbol + format(component.text, 'text') + '\n';
   }
   return out;
 }
 
-export function createRenderedLine(symbol: string, text: string, firstLine: boolean = false) {
-  return createRenderedOutput([{symbol, text}], firstLine);
+export function createRenderedLine(symbol: string, text: string, firstLine: boolean = false, colors?: ColorOptions | boolean, symbolType?: keyof ColorOptions, symbolFormatter?: (v: string) => string) {
+  return createRenderedOutput([{symbol, text, symbolType}], firstLine, -1, colors, symbolFormatter);
 }
 
-export function createFinishingRenderedLine(symbol: string, text: string) {
-  return createRenderedLine(symbol, text) + constants.SHOW_CURSOR;
+export function createFinishingRenderedLine(symbol: string, text: string, colors?: ColorOptions | boolean, symbolType?: keyof ColorOptions, symbolFormatter?: (v: string) => string) {
+  return createRenderedLine(symbol, text, false, colors, symbolType, symbolFormatter) + constants.SHOW_CURSOR;
 }
 
 const isMainCallstack = () => getCallstack().some((call) => call.includes('/dist/') && !call.includes('/test/') && !call.includes('/node_modules/'));
@@ -86,13 +97,7 @@ function getCallstack() {
 export class TickMeasuredSpinner extends Spinner {
   public tickCount = 0;
 
-  constructor(
-    display?: DisplayOptions | string,
-    opts?: {
-      frames?: string[] | undefined;
-      symbols?: Partial<Symbols> | undefined;
-    }
-  ) {
+  constructor(display?: DisplayOptions | string, opts?: SpinnerOptions) {
     super(display, opts);
 
     const originalTick = this.tick.bind(this);


### PR DESCRIPTION
Adds support for a `colors` option to easily apply colours to the spinner using `node:util`'s `styleText`. This will remain off by default until v3.

### Todo:
- [x] Add tests
- [x] Document