### PR TITLE
feat: move to ESM only

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "2.0.0",
   "type": "module",
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    ".": {
+      "default": "./dist/index.js"
+    }
   },
   "engines": {
     "node": ">=18.0.0"
@@ -13,18 +14,16 @@
   "author": "PondWader",
   "description": "A lightweight, no dependency, pluggable CLI spinner library.",
   "scripts": {
-    "build": "tsup ./src/index.ts --format cjs,esm --dts",
+    "build": "tsc",
     "format": "prettier --write src",
-    "test": "tsc && c8 --exclude-after-remap node --test",
+    "test": "npm run build && c8 --exclude-after-remap node --test",
     "lint": "npm run lint:format && eslint src",
     "lint:format": "prettier --check src",
     "bench": "tsc && node ./bench/string-width.mjs"
   },
   "files": [
-    "./dist/index.js",
-    "./dist/index.cjs",
-    "./dist/index.d.ts",
-    "./dist/index.d.cts"
+    "./dist",
+    "!./dist/test"
   ],
   "keywords": [
     "spinner",
@@ -48,7 +47,6 @@
     "prettier": "^3.3.2",
     "string-width": "^7.2.0",
     "tinybench": "^2.8.0",
-    "tsup": "^8.3.5",
     "typescript": "^5.5.2",
     "typescript-eslint": "^7.14.1"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
     "target": "ES2022" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
-    "module": "ES2022" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "module": "nodenext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
@@ -14,7 +14,6 @@
     "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./dist",                             /* Concatenate and emit output to single file. */
     "outDir": "./dist" /* Redirect output structure to the directory. */,
-    "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
     // "removeComments": true,                      /* Do not emit comments to output. */
@@ -40,7 +39,7 @@
     // "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
     /* Module Resolution Options */
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "moduleResolution": "nodenext" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Moves the package to be ESM only now that `require(esm)` is in all LTS other than the soon-to-expire 18.x.

Also drops `tsup` since we can now ship the typescript output as-is.

@PondWader we're trying to coordinate this across all tinylibs repos so your opinion would be super helpful here. I wont merge this until we're in agreement on it 👍 