### PR TITLE
feat: add configurable output stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ setTimeout(() => {
 
 Calling `spinner.stop();` will stop the spinner and remove it.
 
+### Output stream
+
+Spinners write to `process.stdout` by default. To keep stdout available for machine-readable output, pass another stream such as `process.stderr`:
+
+```js
+import {Spinner} from 'picospinner';
+
+const spinner = new Spinner({
+  text: 'Loading...',
+  stream: process.stderr
+});
+```
+
 ### Colours
 
 As of version **3.0.0** colours are enabled by default. This feature uses the [`styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options) function from [`node:util`](https://nodejs.org/api/util.html) if it is available (Node versions greater than **22.0.0**, **21.7.0** or **20.12.0**). If it's not available, no colours will be displayed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import * as constants from './constants.js';
-import {Renderer, TextComponent} from './renderer.js';
+import {Renderer, TextComponent, type OutputStream} from './renderer.js';
 import * as util from 'node:util';
+
+export type {OutputStream} from './renderer.js';
 
 export type Formatter = (input: string) => string;
 
@@ -9,6 +11,7 @@ export type DisplayOptions = {
   text?: string;
   symbol?: string;
   symbolType?: 'succeed' | 'fail' | 'warn' | 'info' | 'spinner';
+  stream?: OutputStream;
 };
 
 export type SpinnerOptions = {
@@ -39,6 +42,8 @@ export type Symbols = {
 // Global renderer so that multiple spinners can run at the same time
 export const renderer = new Renderer();
 
+const renderersByStream = new WeakMap<OutputStream, Renderer>([[process.stdout, renderer]]);
+
 export class Spinner {
   public running = false;
 
@@ -51,6 +56,8 @@ export class Spinner {
   private frames: string[];
   private component = new TextComponent('');
   private colors?: ColorOptions;
+  private stream: OutputStream = process.stdout;
+  private outputRenderer = renderer;
 
   constructor(display: DisplayOptions | string = '', {disableNewLineEnding, colors, frames = constants.DEFAULT_FRAMES, symbols = {} as Partial<Symbols>}: SpinnerOptions = {}) {
     // Merge symbols with defaults
@@ -85,7 +92,7 @@ export class Spinner {
     this.currentSymbol = this.frames[0];
 
     this.tick();
-    renderer.addComponent(this.component);
+    this.outputRenderer.addComponent(this.component);
     this.addListeners();
   }
 
@@ -130,6 +137,7 @@ export class Spinner {
   }
 
   setDisplay(displayOpts: DisplayOptions = {}, render = true) {
+    if (displayOpts.stream) this.setStream(displayOpts.stream);
     if (typeof displayOpts.symbol === 'string') {
       if (typeof displayOpts.symbolType === 'string') {
         this.currentSymbol = this.format(displayOpts.symbol, displayOpts.symbolType);
@@ -140,6 +148,23 @@ export class Spinner {
 
     if (render) this.refresh();
     if (typeof displayOpts.symbol === 'string') this.end();
+  }
+
+  private setStream(stream: OutputStream) {
+    if (stream === this.stream) return;
+
+    const wasRunning = this.running;
+    if (wasRunning) this.outputRenderer.removeComponent(this.component);
+
+    this.stream = stream;
+    let outputRenderer = renderersByStream.get(stream);
+    if (!outputRenderer) {
+      outputRenderer = new Renderer(true, stream);
+      renderersByStream.set(stream, outputRenderer);
+    }
+    this.outputRenderer = outputRenderer;
+
+    if (wasRunning) this.outputRenderer.addComponent(this.component);
   }
 
   setText(text: string, render = true) {
@@ -177,7 +202,7 @@ export class Spinner {
     clearInterval(this.interval);
     this.clearListeners();
     if (keepComponent) this.component.finish();
-    else renderer.removeComponent(this.component);
+    else this.outputRenderer.removeComponent(this.component);
     this.running = false;
   }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,5 +1,10 @@
 import * as constants from './constants.js';
 import {countLines} from './string-lines.js';
+import type {Writable} from 'node:stream';
+
+export interface OutputStream extends Writable {
+  getWindowSize?: () => [number, number];
+}
 
 export class TextComponent {
   onChange?: () => void;
@@ -38,14 +43,17 @@ export class Renderer {
   private finishedComponents = 0;
   private outputBuffer = '';
 
-  constructor(public hideCursor: boolean = true) {}
+  constructor(
+    public hideCursor: boolean = true,
+    private stream: OutputStream = process.stdout
+  ) {}
 
   addComponent(component: TextComponent) {
     this.components.push(component);
     component.onChange = this.render.bind(this);
     component.onFinish = this.onComponentFinish.bind(this);
 
-    if (process.stdout.getWindowSize) this.terminalWidth = process.stdout.getWindowSize()[0];
+    if (this.stream.getWindowSize) this.terminalWidth = this.stream.getWindowSize()[0];
     this.render();
   }
 
@@ -53,7 +61,7 @@ export class Renderer {
     this.finishedComponents++;
     if (this.finishedComponents === this.components.length) {
       this._reset();
-      process.stdout.write(constants.SHOW_CURSOR);
+      this.stream.write(constants.SHOW_CURSOR);
     }
   }
 
@@ -69,8 +77,8 @@ export class Renderer {
     this.clear();
 
     if (this.components.length === 0) {
-      process.stdout.write(this.outputBuffer);
-      if (this.hideCursor) process.stdout.write(constants.SHOW_CURSOR);
+      this.stream.write(this.outputBuffer);
+      if (this.hideCursor) this.stream.write(constants.SHOW_CURSOR);
       this.lastLinesAmt = 0;
       return;
     }
@@ -93,7 +101,7 @@ export class Renderer {
       this.outputBuffer += constants.SHOW_CURSOR;
     }
 
-    process.stdout.write(this.outputBuffer);
+    this.stream.write(this.outputBuffer);
   }
 
   clear() {

--- a/src/test/spinner-test.ts
+++ b/src/test/spinner-test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert/strict';
 import {test} from 'node:test';
 import {ColorOptions, Spinner, Symbols, renderer} from '../index.js';
-import {createFinishingRenderedLine, createRenderedLine, createRenderedOutput, interceptStdout, suppressStdout, TickMeasuredSpinner} from './utils.js';
+import {createFinishingRenderedLine, createRenderedLine, createRenderedOutput, interceptStderr, interceptStdout, suppressStdout, TickMeasuredSpinner} from './utils.js';
 import process from 'node:process';
 import * as constants from '../constants.js';
 
@@ -254,4 +254,19 @@ test('spinner', async (t) => {
   );
   await t.test('displays colors with symbol formatter', () => testSpinner(undefined, 'lorem ipsum dolor', (s) => `a${s}a`, true));
   await t.test('disableNewLineEnding prevents ending new line', () => testSpinner(undefined, undefined, undefined, undefined, true));
+  await t.test('writes to configured stream', async () => {
+    renderer._reset();
+
+    let stdout = '';
+    const stderr = await interceptStderr(async () => {
+      stdout = await interceptStdout(async () => {
+        const spinner = new Spinner({stream: process.stderr}, {colors: false});
+        spinner.start();
+        spinner.stop();
+      });
+    });
+
+    assert.equal(stdout, '');
+    assert.equal(stderr, createRenderedLine(constants.DEFAULT_FRAMES[0], '', true) + constants.CLEAR_LINE + constants.UP_LINE + constants.CLEAR_LINE + constants.SHOW_CURSOR);
+  });
 });

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -42,23 +42,31 @@ export function suppressStdout() {
   return () => (process.stdout.write = stdoutWrite);
 }
 
-export async function interceptStdout(exec: () => Promise<void> | void) {
+async function interceptOutput(stream: NodeJS.WriteStream, exec: () => Promise<void> | void) {
   let output = '';
-  const stdoutWrite = process.stdout.write.bind(process.stdout);
+  const streamWrite = stream.write.bind(stream);
 
   // @ts-expect-error - types are wrong here for the callback
-  capcon.startIntercept(process.stdout, (data: string) => {
-    // Since stdout is used to communicate test data, the interceptor should write data that is not from picospinner to stdout
+  capcon.startIntercept(stream, (data: string) => {
+    // Since output streams are used to communicate test data, the interceptor should write data that is not from picospinner back to the stream
     if (isMainCallstack()) {
       output += data;
-    } else stdoutWrite(data);
+    } else streamWrite(data);
   });
 
   await exec();
 
-  capcon.stopIntercept(process.stdout);
+  capcon.stopIntercept(stream);
 
   return output;
+}
+
+export function interceptStdout(exec: () => Promise<void> | void) {
+  return interceptOutput(process.stdout, exec);
+}
+
+export function interceptStderr(exec: () => Promise<void> | void) {
+  return interceptOutput(process.stderr, exec);
 }
 
 function getCallstack() {


### PR DESCRIPTION
`picospinner` currently writes all spinner frames to `process.stdout`. That is fine for simple interactive CLIs, but it breaks commands that reserve stdout for machine-readable output, such as JSON intended for `jq`, shell scripts, or CI tooling.

This PR adds an optional `stream` field to `DisplayOptions`, so callers can route spinner UI to `stderr`:

```js
  const spinner = new Spinner({
    text: 'Loading...',
    stream: process.stderr,
  });
```

This gives CLI authors a way to follow the common convention (https://clig.dev/#the-basics) that `stdout` is for program output and `stderr` is for status/progress UI, without monkeypatching `picospinner` internals (as I temporary did [here](https://github.com/Automattic/studio/pull/3219)).
The default behavior is unchanged: spinners still write to process.stdout unless a stream is provided.

## Testing instructions
1. Let's assert that no regressions:
```js
node --input-type=module -e "
  import { Spinner } from './dist/index.js';

  const spinner = new Spinner(
    { text: 'Loading...' },
    { colors: false }
  );

  spinner.start(80);

  setTimeout(() => {
    spinner.succeed('Done');
    console.log(JSON.stringify({ ok: true }));
  }, 250);
  "
```
2. Assert that you see:<br /><img width="150" height="45" alt="Screenshot 2026-04-29 at 14 36 19" src="https://github.com/user-attachments/assets/5a15eb09-28c4-46a2-b782-2f455c3bc7d8" />
3. Try the same with stderr:
```js
node --input-type=module -e "
  import { Spinner } from './dist/index.js';

  const spinner = new Spinner(
    { text: 'Loading...', stream: process.stderr },
    { colors: false }
  );

  spinner.start(80);

  setTimeout(() => {
    spinner.succeed('Done');
    console.log(JSON.stringify({ ok: true }));
  }, 250);
  "
```
4. Assert that you see the same:<br /><img width="150" height="45" alt="Screenshot 2026-04-29 at 14 36 19" src="https://github.com/user-attachments/assets/5a15eb09-28c4-46a2-b782-2f455c3bc7d8" />
5. Try using `jq` to assert that it's indeed printed to stderr:<br />
```js
node --input-type=module -e "
  import { Spinner } from './dist/index.js';

  const spinner = new Spinner(
    { text: 'Loading...', stream: process.stderr },
    { colors: false }
  );

  spinner.start(80);

  setTimeout(() => {
    spinner.succeed('Done');
    console.log(JSON.stringify({ ok: true }));
  }, 250);
  " | jq
```
6. Assert that you see no errors and json is parsed well (previously you would get error `jq: parse error: Invalid numeric literal at line 1, column 3`): <br /><img width="178" height="68" alt="Screenshot 2026-04-29 at 14 34 23" src="https://github.com/user-attachments/assets/333f683d-ffa1-4485-9831-5ffc23ddb746" />

@43081j  @PondWader 